### PR TITLE
Added kunday/cloudformer to CloudFormation section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Community Repos:
 * [beaknit/cform](https://github.com/beaknit/cform) - SublimeText plugin.
 * [cloudtools/troposphere :fire::fire::fire:](https://github.com/cloudtools/troposphere) - Python library to create descriptions.
 * [cotdsa/cumulus :fire:](https://github.com/cotdsa/cumulus) - Manages stacks.
+* [kunday/cloudformer](https://github.com/kunday/cloudformer) - Rake helper tasks.
 
 ### CloudSearch
 


### PR DESCRIPTION
Similar in functionality to cumulus (already listed) however has a couple of different features such as support for web hosted CloudFormation templates. Also not to be confused with Amazon's CloudFormer product (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-cloudformer.html).
