### PR TITLE
Add cli53 on Route53 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,6 +781,7 @@ AWS Repos:
 
 Community Repos:
 
+* [barnybug/cli53 :fire::fire::fire:](https://github.com/barnybug/cli53) - cli53 is a command line tool for Amazon Route 53 which provides import and export from BIND format and simple command line management of Route 53 domains.
 * [winebarrel/roadworker :fire:](https://github.com/winebarrel/roadworker) - Roadworker is a tool to manage Route53. It defines the state of Route53 using DSL, and updates Route53 according to DSL.
 
 ### S3


### PR DESCRIPTION
The cli53 (which was previously a python project) written in Go is quite useful for working with Route53 in command line. I think its worth adding in this list.