### PR TITLE
Added aws-fuzzy-finder to EC2 section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ Community Repos:
 * [ConradIrwin/aws-name-server :fire::fire::fire:](https://github.com/ConradIrwin/aws-name-server) - DNS server that lets you look up instances by name.
 * [evannuil/aws-snapshot-tool :fire:](https://github.com/evannuil/aws-snapshot-tool) - Automates EBS snapshots and rotation.
 * [mirakui/ec2ssh :fire:](https://github.com/mirakui/ec2ssh) - SSH config manager.
+* [pmazurek/aws-fuzzy-finder](https://github.com/pmazurek/aws-fuzzy-finder) - SSH into instances using fuzzy search through instances names.
 * [skavanagh/EC2Box :fire::fire:](https://github.com/skavanagh/EC2Box) - A web-based SSH console to manage multiple instances simultaneously.
 * [wbailey/claws :fire:](https://github.com/wbailey/claws) - CLI-driven console with capistrano integration.
 


### PR DESCRIPTION
This package allows you to SSH into your instances by fuzzy-searching through name tags. What is awesome about it, is that it has absolutely no external dependencies (no need to run additional servers etc), and is re-using your boto config (the one you have for aws-cli, ansible etc). That means for most of AWS EC2 users it works out of the box after installation, without further configuring! It is literally just a single-command interactive SSH.

Something I wrote for myself, but I am more than happy to share, as I feel it improved my workflow massively.