### PR TITLE
Add Stack Master - A CLI tool to manage CloudFormation stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Community Repos:
 * [beaknit/cform](https://github.com/beaknit/cform) - SublimeText plugin.
 * [cloudtools/troposphere :fire::fire::fire::fire:](https://github.com/cloudtools/troposphere) - Python library to create descriptions.
 * [cotdsa/cumulus :fire:](https://github.com/cotdsa/cumulus) - Manages stacks.
+* [envato/stack_master](https://github.com/envato/stack_master) - A CLI tool to manage CloudFormation stacks.
 
 ### CloudSearch
 


### PR DESCRIPTION
> 100+ stars for community repos is not a strict requirement, it only serves as a guideline for the initial compilation. If you can vouch for the awesomeness of a repo with < 100 stars and you can explain why it should be listed, please submit a pull request.

At the moment, [StackMaster](https://github.com/envato/stack_master) has ~50 stars on GitHub. But the tool has been battle-tested to manage production stacks in our org for more than a year now. It's been a huge help to improve our productivity and collaboration among dev-ops. It has also lowered the entry barrier significantly for our devs with less ops experience to maintain AWS stacks. I really think it's an **awesome** AWS tool :)

/cc @stevehodgkiss @gstamp @patrobinson @flyinbutrs