### PR TITLE
Add dynamodump - Tool for export/import of DynamoDB data/structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ Community Repos:
 
 * [channl/dynamodb-lambda-autoscale :fire:](https://github.com/channl/dynamodb-lambda-autoscale) - Autoscale DynamoDB provisioned capacity using Lambda.
 * [lyft/confidant :fire::fire::fire:](https://github.com/lyft/confidant) - Stores secrets, encrypted at rest.
+* [mifi/dynamodump](https://github.com/mifi/dynamodump) - Export and import DynamoDB table schema and data.
 * [sebdah/dynamic-dynamodb :fire::fire:](https://github.com/sebdah/dynamic-dynamodb) - Provides auto-scaling.
 
 ### Elastic Beanstalk


### PR DESCRIPTION
Had a hard time finding a simple tool for backing up and restoring both structure (table create, indexes, ...) and data of DynamoDB.