### PR TITLE
Add cristim/autospotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ Community Repos:
 
 * [alestic/ec2-consistent-snapshot :fire::fire:](https://github.com/alestic/ec2-consistent-snapshot) - Initiate consistent EBS snapshots in EC2.
 * [ConradIrwin/aws-name-server :fire::fire::fire:](https://github.com/ConradIrwin/aws-name-server) - DNS server that lets you look up instances by name.
+* [cristim/autospotting](https://github.com/cristim/autospotting) - Automatically rolling-replace on-demand EC2 instances in AutoScaling groups with compatible spot instances.
 * [evannuil/aws-snapshot-tool :fire:](https://github.com/evannuil/aws-snapshot-tool) - Automates EBS snapshots and rotation.
 * [kelseyhightower/kubernetes-the-hard-way :fire::fire::fire::fire::fire:](https://github.com/kelseyhightower/kubernetes-the-hard-way) - Bootstrap Kubernetes the hard way on EC2. No scripts.
 * [mirakui/ec2ssh :fire:](https://github.com/mirakui/ec2ssh) - SSH config manager.


### PR DESCRIPTION
AutoSpotting is a tool I wrote that automatically replaces on-demand instances in existing AutoScaling groups with spot instances, using the Attach/Detach AutoScaling APIs.

Each launched spot instance may be chosen from any cheaper available instance type available on the spot market(compared to the on-demand price of the original instance), as long as it provides at least as much capacity as the original instance.

The original instances may not necessarily need to be available on the spot market, like for example t2 burstable instances could be replaced with more powerful c3.large ones, if they just happen to be the cheapest available.

For those available on the spot market it usually gives the same type or a similar one from another generation, but it can often also give larger instances (with more CPU cores, more memory, more instance store, never smaller), and is configured identically as the original instance: same AZ, storage configuration, user_data, SGs, tags, etc.

See the README file in the referenced [git repository](https://github.com/cristim/autospotting) for more information.

Q: Why is this awesome?
A: Because...
- it allows users to significantly save money by using spot instances
- the instance replacement algorithm it uses is quite sophisticated
- it uses Lambda so it has near-zero cost overhead
## 

Like this pull request?  Vote for it by adding a :+1:
