### PR TITLE
Add AWS Lambda Blog Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,6 +977,7 @@ Community Repos:
 * [niftylettuce/gulp-aws-splash :fire::fire:](https://github.com/niftylettuce/gulp-aws-splash) - Open-source LaunchRock alternative. Build beautiful splash pages.
 * [puppetlabs/puppetlabs-aws :fire:](https://github.com/puppetlabs/puppetlabs-aws) - Puppet module for managing resources to build out infrastructure.
 * [mhart/react-server-routing-example :fire::fire:](https://github.com/mhart/react-server-routing-example) - Sample universal client/server routing and data in React.
+* [sirceljm/LambdaBlogPlatform](https://github.com/sirceljm/LambdaBlogPlatform) - Blogging platform built with Lambda, API Gateway, DynamoDB, S3 and CloudFront.
 * [Spinnaker/spinnaker :fire::fire::fire::fire::fire:](https://github.com/Spinnaker/spinnaker) - Successor to asgard supporting pipelines and more.
 * [spulec/moto :fire::fire::fire:](https://github.com/spulec/moto) - Allows your python tests to easily mock out the boto library.
 


### PR DESCRIPTION
After working with AWS for some time on other projects I decided to make an open source blogging platform that does not require EC2 instances to operate. This platform makes use of API Gateway and Lambda to process user requests. Therefore it is 100% pay what you use and no problem to scale.

https://github.com/sirceljm/LambdaBlogPlatform