### PR TITLE
Add references to the main SparkleFormation projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,9 @@ Community Repos:
 * [cloudtools/troposphere :fire::fire::fire::fire:](https://github.com/cloudtools/troposphere) - Python library to create descriptions.
 * [cotdsa/cumulus :fire:](https://github.com/cotdsa/cumulus) - Manages stacks.
 * [envato/stack_master](https://github.com/envato/stack_master) - A CLI tool to manage CloudFormation stacks.
+* [sparkleformation/sfn](https://github.com/sparkleformation/sfn) - CLI for stack management.
+* [sparkleformation/sparkle_formation :fire:](https://github.com/sparkleformation/sparkle_formation) - Ruby DSL for template creation.
+
 
 ### CloudSearch
 


### PR DESCRIPTION
SparkleFormation and sfn are awesome tools for working with large CloudFormation managed environments.

The DSL is very light, essentially transforming a [supercharged data structure](https://github.com/chrisroberts/attribute_struct) into CloudFormation JSON templates. It supports template inheritance and nesting and supports creating reusable modules (components, dynamic, and registries) that keep large CloudFormation managed environments DRY.

The sfn command line tool makes working with templates and stacks easy and repeatable.