### PR TITLE
Adds docker-lambda-api-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,7 @@ Community Repos:
 * [nficano/python-lambda :fire::fire:](https://github.com/nficano/python-lambda) - A toolkit for developing and deploying serverless Python code in Lambda.
 * [serverless/serverless :fire::fire::fire::fire::fire:](https://github.com/serverless/serverless) The Serverless Application Framework (formerly JAWS).
 * [Tim-B/grunt-aws-lambda :fire::fire:](https://github.com/Tim-B/grunt-aws-lambda) - Grunt plugin.
+* [luisfarzati/docker-lambda-api-server](https://github.com/luisfarzati/docker-lambda-api-server) Run a local Lambda server to run your functions locally and transparently using the AWS SDK or Lambda REST API.
 
 ### Machine Learning
 


### PR DESCRIPTION
## Describe Why This Is Awesome

Why is this awesome?

In the same spirit of [fake-s3](https://github.com/jubos/fake-s3) and the AWS-provided dynamodb local server, docker-lambda-api-server provides a way to run a local AWS Lambda server that you can point your AWS SDK to and use transparently as if you were using the real server (with a few limitations as outlined in the project's README).

Like this pull request?  Vote for it by adding a :+1:

