### PR TITLE
Add ecs-nginx-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ AWS Repos:
 Community Repos:
 
 * [Lumoslabs/broadside](https://github.com/lumoslabs/broadside) - Command line tool for deploying revisions of containerized applications.
+* [codesuki/ecs-nginx-proxy](https://github.com/codesuki/ecs-nginx-proxy) - Reverse proxy for ECS containers. Useful for Continuous Integration.
 
 ### Elastic File System
 


### PR DESCRIPTION
Why is this awesome?
--
The project doesn't have that many stars but it's useful for making test environments accessible by hostname. We are using it to test pull requests. 
