### PR TITLE
Add cavaliercoder/vpc-free - Find free IP address blocks in AWS EC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ AWS Repos:
 Community Repos:
 
 * [alestic/ec2-consistent-snapshot :fire::fire:](https://github.com/alestic/ec2-consistent-snapshot) - Initiate consistent EBS snapshots in EC2.
+* [cavaliercoder/vpc-free](https://github.com/cavaliercoder/vpc-free) - Find free IP address blocks in AWS EC2.
 * [ConradIrwin/aws-name-server :fire::fire::fire:](https://github.com/ConradIrwin/aws-name-server) - DNS server that lets you look up instances by name.
 * [cristim/autospotting :fire::fire:](https://github.com/cristim/autospotting) - Automatically rolling-replace on-demand EC2 instances in AutoScaling groups with compatible spot instances.
 * [evannuil/aws-snapshot-tool :fire:](https://github.com/evannuil/aws-snapshot-tool) - Automates EBS snapshots and rotation.


### PR DESCRIPTION
Managing IPs can be difficult in any network if
not managed effectively from the start. This
tool is awesome because it creates a clear
picture of EC2 VPCs so that good decisions can
be made for building or refactoring networks.
It can also get you out of a pickle when IPs
are limited and you can't find a free block
when searching by hand.

## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the [Contributing Guidelines](https://github.com/donnemartin/awesome-aws/blob/master/CONTRIBUTING.md).

## Describe Why This Is Awesome

Why is this awesome?

--

Like this pull request?  Vote for it by adding a :+1:
