### PR TITLE
Remove Python 3.3 from CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,6 +969,7 @@ AWS Repos:
 
 Community Repos:
 
+* [atlassian/localstack :fire::fire::fire::fire::fire:](https://github.com/atlassian/localstack) - A fully functional local AWS cloud stack. Develop and test your cloud apps offline!
 * [bcoe/thumbd :fire::fire:](https://github.com/bcoe/thumbd) - Node.js/ImageMagick-based image thumbnailing service.
 * [Comcast/cmb :fire::fire:](https://github.com/Comcast/cmb) - Highly available, horizontally scalable queuing and notification service.
 * [convox/rack :fire::fire::fire::fire:](https://github.com/convox/rack) - Open-source PaaS on AWS.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py33, py34, py35
+envlist = py34, py35
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
Travis is now returning ERROR: py33: InterpreterNotFound: python3.3