### PR TITLE
Remove Python 3.3 from CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py33, py34, py35
+envlist = py34, py35
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
Travis is now returning ERROR: py33: InterpreterNotFound: python3.3