### PR TITLE
Remove Python 3.3 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 env:
-  - TOXENV=py33
   - TOXENV=py34
 os:
   - linux


### PR DESCRIPTION
Travis is now returning ERROR: py33: InterpreterNotFound: python3.3.  Previous change only affected tox-based tests, not Travis.