### PR TITLE
Add Axibase TSD as a community repo to AWS EMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,7 @@ AWS Repos:
 Community Repos:
 
 * [Yelp/mrjob :fire::fire::fire::fire::fire:](https://github.com/Yelp/mrjob) - Run MapReduce jobs on Hadoop or EMR.
+* [Axibase Time Series Database :fire:](https://github.com/axibase/atsd/blob/master/installation/aws-emr-s3.md) - Time series database supported on AWS EMR S3
 
 ### Elastic Search
 


### PR DESCRIPTION
Our starred repo is https://github.com/axibase/atsd-use-cases however I set a link to an EMR-specific document. Not sure what's the right way to approach this. Couldn't find a guideline in the 'contributing' doc. We also have an integration with CloudWatch.

## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the [Contributing Guidelines](https://github.com/donnemartin/awesome-aws/blob/master/CONTRIBUTING.md).

## Describe Why This Is Awesome

Why is this awesome?

It's a time series database that runs on AWS EMR with S3 as the underlying storage. It makes life easier for DBAs by significantly reducing the management overhead of running a full-blown Hadoop cluster.

--

Like this pull request?  Vote for it by adding a :+1:
