### PR TITLE
Fix link to AWSome Day Online Conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,7 +1241,7 @@ AWS Conferences:
 
 * [re:Invent](https://reinvent.awsevents.com/) - Annual user conference. The event features keynote announcements, training and certification opportunities, over 250 technical sessions, a partner expo, after hours activities, and more.
 * [Summits](https://aws.amazon.com/summits/) - Global one-day events that are designed to educate new customers about the AWS platform and offer existing customers deep technical content to be more successful with AWS.
-* [AWSome Day](https://aws.amazon.com/events/awsome-day-roadshow-mar-2015/) - Global one-day events are delivered by AWS Education's technical instructors and are ideal for IT pros, developers and technical managers who would like to learn about how to get started in the AWS Cloud.
+* [AWSome Day](https://aws.amazon.com/events/awsome-day/awsome-day-online/) - Global one-day events are delivered by AWS Education's technical instructors and are ideal for IT pros, developers and technical managers who would like to learn about how to get started in the AWS Cloud.
 
 Community Conferences:
 


### PR DESCRIPTION
The earlier link to AWSome Day Online Conference was old and showing 404 error. AWSome Day Online Conference is held on 31 Oct 2017, updated the link.

## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the [Contributing Guidelines](https://github.com/donnemartin/awesome-aws/blob/master/CONTRIBUTING.md).

## Describe Why This Is Awesome

Why is this awesome?

AWSome Day Online is awesome event for learning and hosted by AWS itself for free.

Like this pull request?  Vote for it by adding a :+1:
