### PR TITLE
Update boto/boto links to boto/boto3

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Related Repos:
 
 ### Python SDK
 
-* [Repo :fire::fire::fire::fire::fire:](https://github.com/boto/boto)
+* [Repo :fire::fire::fire::fire::fire:](https://github.com/boto/boto3)
 * [Repo with Samples](https://github.com/awslabs/aws-python-sample)
 * [Install](http://github.com/boto/boto#installation)
 * [Docs](http://docs.pythonboto.org/en/latest/)


### PR DESCRIPTION
The boto repo description links to boto/boto3 instead of boto/boto

https://github.com/boto/boto
https://github.com/boto/boto3

## Describe Why This Is Awesome

The author things boto3 is more awesome than boto now. 

--

Like this pull request?  Vote for it by adding a :+1:
