### PR TITLE
Add nccgroup/AWS-recipes - A number of Recipes for AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,7 @@ Community Repos:
 * [localstack/localstack ](https://github.com/atlassian/localstack) - A fully functional local AWS cloud stack. Develop and test your cloud apps offline!
 * [meducation/propono :fire::fire:](https://github.com/meducation/propono) - Easy-to-use pub/sub in Ruby.
 * [mozilla/awsbox :fire::fire::fire:](https://github.com/mozilla/awsbox) - A featherweight PaaS on top of EC2 for deploying node apps.
+* [nccgroup/AWS-recipes :fire:](https://github.com/nccgroup/AWS-recipes) - A number of Recipes for AWS.
 * [Netflix/aminator :fire::fire::fire:](https://github.com/Netflix/aminator) - A tool for creating EBS AMIs.
 * [Netflix/archaius :fire::fire::fire::fire:](https://github.com/Netflix/archaius) - Library for configuration management API.
 * [Netflix/asgard :fire::fire::fire::fire::fire:](https://github.com/Netflix/asgard) - Web interface for application deployments and cloud management.


### PR DESCRIPTION
This repository contains recipes that are designed to help improve security in AWS.  It also contains recipes for CloudFormation templates and IAM policies.

--

Like this pull request?  Vote for it by adding a :+1: