### PR TITLE
Add ecs-blue-green-deployment - Reference architecture for doing blue green deployments on ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,7 @@ AWS Repos:
 * [amazon-ecs-amazon-efs](https://github.com/awslabs/amazon-ecs-amazon-efs) - Persists Data from containers.
 * [amazon-ecs-init](https://github.com/aws/amazon-ecs-init) - RPM developed to support the Amazon ECS Container Agent.
 * [blox :fire::fire::fire:](https://github.com/blox/blox) - Open source tools for building custom schedulers on ECS.
+* [ecs-blue-green-deployment :fire:](https://github.com/awslabs/ecs-blue-green-deployment) - Blue-green deployment on ECS.
 * [ecs-cloudwatch-logs](https://github.com/awslabs/ecs-cloudwatch-logs) - Assets from the blog using Amazon ECS and Amazon CloudWatch logs.
 * [ecs-demo-php-simple-app](https://github.com/awslabs/ecs-demo-php-simple-app) - Simple PHP app.
 * [ecs-mesos-scheduler-driver :fire:](https://github.com/awslabs/ecs-mesos-scheduler-driver) - Integrates Apache Mesos.


### PR DESCRIPTION
## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the [Contributing Guidelines](https://github.com/donnemartin/awesome-aws/blob/master/CONTRIBUTING.md).

## Describe Why This Is Awesome

A good reference architecture on how to implement blue-green deployment on ECS using CloudFormation and CodePipeline.

--

Like this pull request?  Vote for it by adding a :+1:
