### PR TITLE
added cfn-include

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Community Repos:
 * [beaknit/cform](https://github.com/beaknit/cform) - SublimeText plugin.
 * [cloudreach/sceptre] :fire::fire:](https://github.com/cloudreach/sceptre) - A CLI tool for automating CloudFormation.
 * [cloudtools/troposphere :fire::fire::fire::fire::fire:](https://github.com/cloudtools/troposphere) - Python library to create descriptions.
+* [monken/cfn-include](https://github.com/monken/cfn-include) - Preprocessor with flexible Fn::Include for CloudFormation templates.
 * [peterkh/cumulus :fire::fire:](https://github.com/peterkh/cumulus) - Manages stacks.
 * [envato/stack_master :fire:](https://github.com/envato/stack_master) - A CLI tool to manage CloudFormation stacks.
 * [sparkleformation/sfn](https://github.com/sparkleformation/sfn) - CLI for stack management.


### PR DESCRIPTION
## Describe Why This Is Awesome

`cfn-include` has been around for a while and its community is growing. You can do pretty cool things with it, like integrating responses from AWS APIs directly into the template or including remote and local files (e.g. code for lambda functions).

```
# let an API return the AMI per region mapping for you:
Mappings:
  Region2AMI:
    !Include https://api.netcubed.de/latest/ami/lookup?platform=amzn2
```

--

Like this pull request?  Vote for it by adding a :+1:
