### PR TITLE
Add Appliscale/perun - A CLI tool for linting/validation and managing CloudFormation templates and stacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ AWS Repos:
 
 Community Repos:
 
+* [Appliscale/perun](https://github.com/Appliscale/perun) - A CLI tool for linting/validation and managing CloudFormation templates and stacks.
 * [bazaarvoice/cloudformation-ruby-dsl :fire:](https://github.com/bazaarvoice/cloudformation-ruby-dsl) - Ruby DSL for creating templates.
 * [beaknit/cform](https://github.com/beaknit/cform) - SublimeText plugin.
 * [cloudreach/sceptre] :fire::fire:](https://github.com/cloudreach/sceptre) - A CLI tool for automating CloudFormation.
@@ -447,7 +448,6 @@ Community Repos:
 * [envato/stack_master :fire:](https://github.com/envato/stack_master) - A CLI tool to manage CloudFormation stacks.
 * [sparkleformation/sfn](https://github.com/sparkleformation/sfn) - CLI for stack management.
 * [sparkleformation/sparkle_formation :fire:](https://github.com/sparkleformation/sparkle_formation) - Ruby DSL for template creation.
-
 
 ### CloudSearch
 


### PR DESCRIPTION
Swiss army knife for AWS CloudFormation templates - validation, conversion, generators and other various stuff.

--

Like this pull request?  Vote for it by adding a :+1:
