### PR TITLE
add ecr-promote cli tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ AWS Repos:
 Community Repos:
 
 * [Lumoslabs/broadside](https://github.com/lumoslabs/broadside) - Command line tool for deploying revisions of containerized applications.
+* [segersniels/ecr-promote :fire:](https://github.com/segersniels/ecr-promote) - CLI tool to easily promote ECR images between environments by selecting CircleCI builds.
 
 ### Elastic File System
 


### PR DESCRIPTION
## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the [Contributing Guidelines](https://github.com/donnemartin/awesome-aws/blob/master/CONTRIBUTING.md).

## Describe Why This Is Awesome

Why is this awesome?
Working with a lot of microservices can make it chaotic to promote a lot of image versions between environments. 

*ecr-promote* tries to solve this by letting the user select a *CircleCI* build through an interactive prompt to promote between these accounts. It currently only supports *CircleCI* as a CI base, but I'm open to suggestions to add other CI tools.

eg. *CircleCI* builds staging images and `ecr-promote` allows the user to easily promote them to a production account (by fuzzy matching git repos to ECR repos).

Written in Go.
--

Like this pull request?  Vote for it by adding a :+1:
