### PR TITLE
Add awsudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ Community Repos:
 * [timkay/aws :fire::fire:](https://github.com/timkay/aws) - Easy command line access to Amazon EC2, S3, SQS, ELB, and SDB.
 * [wallix/awless :fire::fire::fire::fire::fire:](https://github.com/wallix/awless) - a Powerful CLI for EC2, IAM and S3 in Go.
 * [99designs/aws-vault :fire::fire::fire::fire:](https://github.com/99designs/aws-vault) - A tool for securely storing AWS credentials, written in Go.
+* [marceloboeira/awsudo](https://github.com/marceloboeira/awsudo) - sudo-like behavior for role assumed access on AWS accounts.
 
 ### CloudFormation
 


### PR DESCRIPTION
## Why is this awesome?
> sudo-like behavior for role assumed access on AWS accounts

The idea is that you can generate/cache/inject tokens for other IAM roles/profiles onto shell programs.

e.g.: 

`terraform plan` (which requires access to S3 bucket) 

Can be simply: `awsudo -u staging terraform plan`

OR with aliases:  `awss t plan`

e.g.:

* `awso t plan` (operations)
* `awsp t plan` (production)

also, for other local development tasks ... 

* `awsd ./my-local-s3-consumer` (from dev)

* `awss ./my-local-kinesis-consumer` (from stating)




--

Like this pull request?  Vote for it by adding a :+1: