### PR TITLE
Add numblr/glaciertools - Bash scripts for multipart uploads to Glacier

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ Community Repos:
 
 Community Repos:
 
+* [numblr/glaciertools](https://github.com/numblr/glaciertools) - Simple bash scripts on top of aws-cli for multipart uploads to Glacier.
 * [vsespb/mt-aws-glacier :fire::fire:](https://github.com/vsespb/mt-aws-glacier) - Perl Multithreaded Multipart sync to Glacier.
 
 ### Kinesis


### PR DESCRIPTION
## Why is this awesome?

The included bash scripts provide an easy way to upload large files directly from the command line to Glacier. If you have the aws-cli installed and setup they require only a minimal set of additional dependencies (openssl and GNU Parallel) and therefore run with almost no additional setup on Linux and OS X.

Like this pull request?  Vote for it by adding a :+1:
