### PR TITLE
Add GorillaStack/auto-tag - Automatically tag AWS resources on creation, for cost assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ AWS Repos:
 Community Repos:
 
 * [AppliedTrust/traildash :fire::fire:](https://github.com/AppliedTrust/traildash) - Slick dashboard.
-* [GorillaStack/auto-tag :fire::fire:](https://github.com/GorillaStack/auto-tag) - Automatically tag AWS resources on creation, for cost assignment
+* [GorillaStack/auto-tag :fire::fire:](https://github.com/GorillaStack/auto-tag) - Automatically tag AWS resources on creation, for cost assignment.
 
 ### CloudWatch
 

--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ AWS Repos:
 Community Repos:
 
 * [AppliedTrust/traildash :fire::fire:](https://github.com/AppliedTrust/traildash) - Slick dashboard.
+* [GorillaStack/auto-tag :fire::fire:](https://github.com/GorillaStack/auto-tag) - Automatically tag AWS resources on creation, for cost assignment
 
 ### CloudWatch
 


### PR DESCRIPTION
## Why is this awesome?

> Automatically tag AWS resources on creation, for cost assignment

Use CloudTrail and CloudWatch Events to automatically tag supported AWS resources with the creator's ARN and the create date/time. This gives users a quick way to find the age of the AWS resource and who created it.


--

Like this pull request?  Vote for it by adding a :+1:
