### PR TITLE
Add go-aws-news

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,6 +980,7 @@ AWS Repos:
 Community Repos:
 
 * [bcoe/thumbd :fire::fire:](https://github.com/bcoe/thumbd) - Node.js/ImageMagick-based image thumbnailing service.
+* [circa10a/go-aws-news](https://github.com/circa10a/go-aws-news) - A Go library to fetch AWS product announcements.
 * [Comcast/cmb :fire::fire:](https://github.com/Comcast/cmb) - Highly available, horizontally scalable queuing and notification service.
 * [convox/rack :fire::fire::fire::fire:](https://github.com/convox/rack) - Open-source PaaS on AWS.
 * [devops-israel/aws-inventory :fire::fire:](https://github.com/devops-israel/aws-inventory) - Display all your AWS resources on a single web page.


### PR DESCRIPTION
Why is this awesome?

[go-aws-news](https://github.com/circa10a/go-aws-news) is the only way I've seen to programmatically access AWS product/feature announcements. This would allow folks to automatically update internal communication channels within their companies for products/resources that matter to them.

Like this pull request?  Vote for it by adding a :+1:
