### PR TITLE
Add bash-my-aws/bash-my-aws - Pipe-Skimming CLI Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Related Repos:
 Related Repos:
 
 * [awslabs/aws-shell :fire::fire::fire::fire::fire:](https://github.com/awslabs/aws-shell)
+* [bash-my-aws/bash-my-aws :fire::fire::fire:](https://github.com/bash-my-aws/bash-my-aws)
 * [donnemartin/saws :fire::fire::fire::fire::fire:](https://github.com/donnemartin/saws)
 
 ### Windows PowerShell
@@ -410,6 +411,7 @@ AWS Repos:
 Community Repos:
 
 * [achiku/jungle :fire::fire::fire:](https://github.com/achiku/jungle) - Operations by EC2 and ELB cli should be simpler.
+* [bash-my-aws/bash-my-aws :fire::fire::fire:](https://github.com/bash-my-aws/bash-my-aws) - Pipe-Skimming CLI Commands for managing AWS Resources.
 * [dbcli/athenacli](https://github.com/dbcli/athenacli) - a CLI tool for AWS Athena service that can do auto-completion and syntax highlighting.
 * [donnemartin/saws :fire::fire::fire::fire::fire:](https://github.com/donnemartin/saws) - A Supercharged AWS Command Line Interface.
 * [timkay/aws :fire::fire:](https://github.com/timkay/aws) - Easy command line access to Amazon EC2, S3, SQS, ELB, and SDB.


### PR DESCRIPTION
Why is this awesome?

Allows you to pipe output from commands into each other using a pattern called [Pipe-Skimming](https://bash-my-aws.org/pipe-skimming/)

Here we list EC2 Instances running in an Amazon AWS Account:

    $ instances
    i-09d962a1d688bb3ec  t3.nano   running  grafana-bma  2020-01-16T03:53:44.000Z
    i-083f73ad5a1895ba0  t3.small  running  huginn-bma   2020-01-16T03:54:24.000Z
    i-0e219fbee42347721  t3.nano   running  nginx-bma    2020-01-16T03:56:22.000Z


Piping output from this command into `instance-asg` returns a list of
AutoScaling Groups (ASGs) they belong to:

    $ instances | instance-asg
    huginn-bma-AutoScalingGroup-QS7EQOT1G7OX    i-083f73ad5a1895ba0
    nginx-bma-AutoScalingGroup-106KHAYHUSRHU    i-0e219fbee42347721
    grafana-bma-AutoScalingGroup-1NXJHMJVZQVMB  i-09d962a1d688bb3ec

- [Documentation homepage](https://bash-my-aws.org/)

Support for the following resource types:

- asgs
- aws-account
- acm
- cloudtrail
- ecr
- elb
- elbv2
- iam
- image
- instance
- keypair
- kms
- lambda
- log-group
- rds
- region
- route53
- s3
- stack
- sts
- vpc


--

Like this pull request?  Vote for it by adding a :+1:
