### PR TITLE
Add cdk-patterns/serverless - Deployable serverless architecture patterns built in AWS CDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,7 +980,7 @@ AWS Repos:
 Community Repos:
 
 * [bcoe/thumbd :fire::fire:](https://github.com/bcoe/thumbd) - Node.js/ImageMagick-based image thumbnailing service.
-* [cdkpatterns](https://github.com/cdk-patterns/serverless) - An opensource repo containing deployable serverless arch patterns built in aws cdk.
+* [cdkpatterns](https://github.com/cdk-patterns/serverless) - An opensource repo containing deployable serverless arch patterns built in AWS CDK.
 * [Comcast/cmb :fire::fire:](https://github.com/Comcast/cmb) - Highly available, horizontally scalable queuing and notification service.
 * [convox/rack :fire::fire::fire::fire:](https://github.com/convox/rack) - Open-source PaaS on AWS.
 * [devops-israel/aws-inventory :fire::fire:](https://github.com/devops-israel/aws-inventory) - Display all your AWS resources on a single web page.

--- a/README.md
+++ b/README.md
@@ -980,7 +980,7 @@ AWS Repos:
 Community Repos:
 
 * [bcoe/thumbd :fire::fire:](https://github.com/bcoe/thumbd) - Node.js/ImageMagick-based image thumbnailing service.
-* [cdkpatterns](https://github.com/cdk-patterns/serverless) - An opensource repo containing deployable serverless arch patterns built in AWS CDK.
+* [cdkpatterns](https://github.com/cdk-patterns/serverless) - Deployable serverless architecture patterns built in AWS CDK.
 * [Comcast/cmb :fire::fire:](https://github.com/Comcast/cmb) - Highly available, horizontally scalable queuing and notification service.
 * [convox/rack :fire::fire::fire::fire:](https://github.com/convox/rack) - Open-source PaaS on AWS.
 * [devops-israel/aws-inventory :fire::fire:](https://github.com/devops-israel/aws-inventory) - Display all your AWS resources on a single web page.

--- a/README.md
+++ b/README.md
@@ -980,6 +980,7 @@ AWS Repos:
 Community Repos:
 
 * [bcoe/thumbd :fire::fire:](https://github.com/bcoe/thumbd) - Node.js/ImageMagick-based image thumbnailing service.
+* [cdkpatterns](https://github.com/cdk-patterns/serverless) - An opensource repo containing deployable serverless arch patterns built in aws cdk.
 * [Comcast/cmb :fire::fire:](https://github.com/Comcast/cmb) - Highly available, horizontally scalable queuing and notification service.
 * [convox/rack :fire::fire::fire::fire:](https://github.com/convox/rack) - Open-source PaaS on AWS.
 * [devops-israel/aws-inventory :fire::fire:](https://github.com/devops-israel/aws-inventory) - Display all your AWS resources on a single web page.


### PR DESCRIPTION
Why is this awesome?

This is an opensource repo containing serverless architecture patterns with links to the person who created it and all their source material. Since these patterns are built in cdk they are available in TypeScript and Python but also in CloudFormation since that is what cdk uses to deploy. You do not have to use cdk to get value from this repo.

You can just clone this repo, cd into the pattern you want, install the dependencies and run the deploy task to learn. 

Like this pull request?  Vote for it by adding a :+1:
