### PR TITLE
Add baby walkthrough for ECS deployment via GitHub on master push

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,7 @@ Community Repos:
 
 * [Lumoslabs/broadside](https://github.com/lumoslabs/broadside) - Command line tool for deploying revisions of containerized applications.
 * [Stelligent/mu :fire::fire::fire:](https://github.com/stelligent/mu) - Command line tool to simplify ECS deployments via CodeBuild and CodePipeline.
+* [Andrew-Chen-Wang/cookiecutter-django-ecs-github](https://github.com/Andrew-Chen-Wang/cookiecutter-django-ecs-github) - Complete baby walkthrough on deploying from GitHub on master push via CodeDeploy
 
 ### Elastic File System
 


### PR DESCRIPTION
## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the [Contributing Guidelines](https://github.com/donnemartin/awesome-aws/blob/master/CONTRIBUTING.md).

## Describe Why This Is Awesome

Why is this awesome?

It's a guide + ready-to-go code for ECS blue/green deployment using GitHub Actions + CodeDeploy, and your code is deployed automatically with GitHub actions on push from master.

There are almost no good walkthroughs for ECS deployment. I wrote a complete walkthrough, **everything** filled out completely with justification/explanations, with code ready to go (noted what files are necessary if you're not using Django of course). It includes an nginx reverse proxy configuration behind an ALB with Route 53 + ACM and all necessary files included with its content. Pretty much anything you need for an ECS deployment is here.

--

Like this pull request?  Vote for it by adding a :+1:
