### PR TITLE
Add rahulpsd18/cognito-backup-restore - Tool for backing up and restoring Cognito user pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ AWS Repos:
 Community Repos:
 
 * [capeless/warrant :fire::fire:](https://github.com/capless/warrant) - Python library for using Cognito.
+* [rahulpsd18/cognito-backup-restore :fire:](https://github.com/rahulpsd18/cognito-backup-restore) - AIO Tool for backing up and restoring AWS Cognito User Pools.
 
 ### Data Pipeline
 

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ AWS Repos:
 Community Repos:
 
 * [capeless/warrant :fire::fire:](https://github.com/capless/warrant) - Python library for using Cognito.
-* [rahulpsd18/cognito-backup-restore :fire:](https://github.com/rahulpsd18/cognito-backup-restore) - AIO Tool for backing up and restoring AWS Cognito User Pools.
+* [rahulpsd18/cognito-backup-restore :fire:](https://github.com/rahulpsd18/cognito-backup-restore) - Tool for backing up and restoring Cognito user pools.
 
 ### Data Pipeline
 


### PR DESCRIPTION
## Why is this awesome?

`cognito-backup-restore` is an AIO Tool for backing up and restoring AWS Cognito User Pools

Amazon Cognito is awesome, but has its own set of limitations. Currently there is no backup option provided in case we need to take backup of users (to move to another service) or restore them to new Userpool.

`cognito-backup-restore` tries to overcome this problem by providing a way to backup users from cognito pool(s) to json file and vice-versa.

---

Like this pull request?  Vote for it by adding a :+1:
