### PR TITLE
Add GoogleCloudPlatform/terraformer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,6 +998,7 @@ Community Repos:
 * [donnemartin/dev-setup :fire::fire::fire::fire:](https://github.com/donnemartin/dev-setup) - Mac setup of various developer tools and AWS services.
 * [dtan4/terraforming :fire::fire::fire::fire::fire:](https://github.com/dtan4/terraforming) - Export existing resources to Terraform style (tf, tfstate).
 * [segmentio/stack :fire::fire::fire::fire::fire:](https://github.com/segmentio/stack) - A set of Terraform modules for configuring production infrastructure.
+* [GoogleCloudPlatform/terraformer :fire::fire::fire::fire::fire:](https://github.com/GoogleCloudPlatform/terraformer#use-with-aws) - A tool that generates tf/json and tfstate files based on existing infrastructure (reverse Terraform). (Originally from Waze SRE team, but mostly cloud-agnostic)
 * [j2labs/microarmy ](https://github.com/j2labs/microarmy) - Deploy micro instances to launch a coordinated siege.
 * [jpillora/grunt-aws :fire:](https://github.com/jpillora/grunt-aws) - Grunt interface into the Node.JS SDK.
 * [jvehent/haproxy-aws :fire::fire:](https://github.com/jvehent/haproxy-aws) - Documentation on building a HTTPS stack with HAProxy.


### PR DESCRIPTION
## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the [Contributing Guidelines](https://github.com/donnemartin/awesome-aws/blob/master/CONTRIBUTING.md).

## Describe Why This Is Awesome

Why is this awesome?

This tool, from the Waze SRE team, uses Terraform code itself to do a 'reverse terraform' - exporting terraform code and state from existing infrastructure. While it started with Google Cloud-centric approach, it supports major cloud API providers like AWS, Azure, and several other Terraform providers (like Datadog, New Relic, Kubernetes, etc.). Can compliment the output of 'terraforming' project - where each can help 'fill in the blanks' of the other's generated code.
 
Like this pull request?  Vote for it by adding a :+1:
