### PR TITLE
Add modular AWS SDK for JavaScript (v3) link

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ Related Repos:
 
 ### JavaScript SDK
 
-* [Repo :fire::fire::fire::fire::fire:](https://github.com/aws/aws-sdk-js)
+* [Repo for version 3 (v3) :fire::fire::fire](https://github.com/aws/aws-sdk-js-v3)
+* [Repo for version 2 (v2) :fire::fire::fire::fire::fire:](https://github.com/aws/aws-sdk-js)
 * [Repo with Samples :fire::fire:](https://github.com/awslabs/aws-nodejs-sample)
 * [Install](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-intro.html)
 * [Docs](https://aws.amazon.com/documentation/sdk-for-javascript/)


### PR DESCRIPTION
Blog post on General Availability of modular AWS SDK for JavaScript (v3)
https://aws.amazon.com/blogs/developer/modular-aws-sdk-for-javascript-is-now-generally-available/

## Review the Contributing Guidelines

All requirements in the [Contributing Guidelines](https://github.com/donnemartin/awesome-aws/blob/master/CONTRIBUTING.md) are verified.

## Describe Why This Is Awesome

Official repo of modular AWS SDK for JavaScript (v3) 

--

Like this pull request?  Vote for it by adding a :+1:
