### PR TITLE
Add Stacktape (DevOps-free application development)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,6 +1023,7 @@ Community Repos:
 * [snowplow/snowplow :fire::fire::fire::fire::fire:](https://github.com/snowplow/snowplow) - Enterprise-strength web, mobile and event analytics, powered by Hadoop, Kafka, Kinesis, Redshift and Elasticsearch.
 * [Spinnaker/spinnaker :fire::fire::fire::fire::fire:](https://github.com/Spinnaker/spinnaker) - Successor to asgard supporting pipelines and more.
 * [spulec/moto :fire::fire::fire::fire::fire:](https://github.com/spulec/moto) - Allows your python tests to easily mock out the boto library.
+* [Stacktape/stacktape](https://github.com/stacktape/stacktape) - DevOps-free application development framework.
 
 ## Guides, Books, Documentation, and Training
 


### PR DESCRIPTION
Hi, Stacktape CEO here. 

After 2.5 years in development, I'm happy to introduce [Stacktape](https://stacktape.com) - DevOps-free application development framework.

## Describe Why This Is Awesome

- Stacktape offers the full power of AWS with Heroku-like experience. 
- It allows any developer to develop, deploy and run applications on AWS with 98% less configuration. 
- No Cloud or DevOps expertise required.

## Features

- Automates infrastructure management, source-code packaging, deployments, local debugging & much more.
- Supports 20+ "higher-level" AWS infrastructure components, including Lambda functions, Containers, SQL databases, Redis clusters, Load balancers, and more. It also supports other fully-managed infrastructure services deployable to AWS (currently MongoDB Atlas clusters and Upstash Redis/Kafka).
- Comes with a VS code editor extension and local development studio (GUI).
- A typical production-grade REST API is ~30 lines of Stacktape config (compared to ~600-800 lines of CloudFormation/Terraform).

--

Like this pull request?  Vote for it by adding a :+1:
